### PR TITLE
Bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Refresh auth token when retrying
+- Extended TCP timeout to handle long http timeouts
+
 ## 0.1.3
 
 - Also return response message in error cases


### PR DESCRIPTION
1. Refresh auth token in request when retrying #21 
2. Add TCP timeout to overcome default 2 minutes timeout #19 